### PR TITLE
Fix terminal color support for xterm-256color and similar terminals

### DIFF
--- a/src/linux32gcc.gmk
+++ b/src/linux32gcc.gmk
@@ -96,7 +96,7 @@ endif
 # Preference now is to use "ncurses" rather than "termcap", figure out if ncurses is avaiable or if we must fall back to termcap.
 #
 CONSOLE_LIBS  = -lncurses
-CONSOLE_DEFS  = -D_USE_NCURSES
+CONSOLE_DEFS  = -D_USE_NCURSES -D_USETPARM
 
 ifeq "$(BTYP)" "c"
 BTYP_CDF = $(CONSOLE_DEFS) -D_ME_CONSOLE

--- a/src/unixterm.c
+++ b/src/unixterm.c
@@ -2417,6 +2417,19 @@ TCAPstart(void)
         }
     } while(--ii >= 0);
     
+#if MEOPT_COLOR
+    if ((tcaptab[TCAPsetaf].code.str != NULL) || (tcaptab[TCAPsetab].code.str != NULL))
+    {
+        meSystemCfg |= meSYSTEM_ANSICOLOR;
+    }
+    else if ((strncmp(tv_stype, "xterm", 5) == 0) ||
+             (strncmp(tv_stype, "screen", 6) == 0) ||
+             (strncmp(tv_stype, "tmux", 4) == 0))
+    {
+        meSystemCfg |= meSYSTEM_ANSICOLOR;
+    }
+#endif
+    
     /* Make sure that there was sufficient buffer space to process the strings */
     if (p >= &tcapbuf[TCAPSLEN])
     {


### PR DESCRIPTION
- Add -D_USETPARM to use system tparm() which supports complex color escape sequences (e.g., xterm-256color uses ? conditional)
- Add automatic color capability detection in TCAPstart() to set meSYSTEM_ANSICOLOR when termcap finds color capabilities
- Fallback for xterm/screen/tmux variants without explicit color entries

This fixes the issue where TERM=xterm-256color or TERM=tmux-256color did not display colors, requiring TERM=xterm workaround.